### PR TITLE
 Zend_Json to Laminas\Json - Fix for Magento 2.4.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ view/base/web/build/*.css
 view/base/web/build/*.js
 !view/base/web/build/*.min.js
 Developer.php
-
+/vendor/
+/composer.lock

--- a/Builder/Base/AbstractCss.php
+++ b/Builder/Base/AbstractCss.php
@@ -21,7 +21,6 @@ use Goomento\PageBuilder\Helper\ConfigHelper;
 use Goomento\PageBuilder\Helper\ObjectManagerHelper;
 use Goomento\PageBuilder\Helper\StateHelper;
 use Goomento\PageBuilder\Helper\ThemeHelper;
-use Zend_Json_Exception;
 
 abstract class AbstractCss extends AbstractFile
 {
@@ -686,7 +685,7 @@ abstract class AbstractCss extends AbstractFile
      *
      * @param array $control The control.
      * @param string $value The value.
-     * @throws Zend_Json_Exception
+     * @throws \Laminas\Json\Exception\ExceptionInterface
      */
     protected function addDynamicControlStyleRules(array $control, string $value)
     {

--- a/Builder/Base/AbstractDocument.php
+++ b/Builder/Base/AbstractDocument.php
@@ -175,7 +175,7 @@ abstract class AbstractDocument extends ControlsStack
         ];
 
         if (!StateHelper::isEditorPreviewMode()) {
-            $attributes['data-gmt-settings'] = \Zend_Json::encode($this->getFrontendSettings());
+            $attributes['data-gmt-settings'] = \Laminas\Json\Json::encode($this->getFrontendSettings());
         }
 
         return $attributes;

--- a/Builder/Base/AbstractElement.php
+++ b/Builder/Base/AbstractElement.php
@@ -15,7 +15,6 @@ use Goomento\PageBuilder\Helper\HooksHelper;
 use Goomento\PageBuilder\Helper\ObjectManagerHelper;
 use Goomento\PageBuilder\Helper\ThemeHelper;
 use Magento\Framework\Phrase;
-use Zend_Json;
 
 abstract class AbstractElement extends ControlsStack
 {
@@ -766,7 +765,7 @@ abstract class AbstractElement extends ControlsStack
 
         if ($frontendSettings) {
             // This FE config use for system handlers, such as background video player at section ...
-            $this->addRenderAttribute('_wrapper', 'data-settings', Zend_Json::encode($frontendSettings));
+            $this->addRenderAttribute('_wrapper', 'data-settings', \Laminas\Json\Json::encode($frontendSettings));
         }
 
         /**

--- a/Builder/Base/AbstractWidget.php
+++ b/Builder/Base/AbstractWidget.php
@@ -441,7 +441,7 @@ abstract class AbstractWidget extends AbstractElement
                 $initScripts[$script] = $frontendSettings ?: [];
             }
             // Use `_container` for render via AJAX
-            $this->addRenderAttribute('_container', 'data-mage-init', \Zend_Json::encode($initScripts));
+            $this->addRenderAttribute('_container', 'data-mage-init', \Laminas\Json\Json::encode($initScripts));
         }
 
         ?>

--- a/Builder/Managers/Sources.php
+++ b/Builder/Managers/Sources.php
@@ -18,7 +18,6 @@ use Goomento\PageBuilder\Helper\HooksHelper;
 use Goomento\PageBuilder\Helper\AuthorizationHelper;
 use Goomento\PageBuilder\Helper\ObjectManagerHelper;
 use Goomento\PageBuilder\Traits\TraitComponentsLoader;
-use Zend_Json;
 
 // phpcs:disable Magento2.Functions.DiscouragedFunction.Discouraged
 class Sources
@@ -145,7 +144,7 @@ class Sources
         }
 
         try {
-            $args['content'] = Zend_Json::decode($args['content']);
+            $args['content'] = \Laminas\Json\Json::decode($args['content']);
         } catch (\Exception $e) {
             $args['content'] = [];
         }

--- a/Builder/Managers/Sources.php
+++ b/Builder/Managers/Sources.php
@@ -144,7 +144,7 @@ class Sources
         }
 
         try {
-            $args['content'] = \Laminas\Json\Json::decode($args['content']);
+            $args['content'] = \Laminas\Json\Json::decode($args['content'], \Laminas\Json\Json::TYPE_ARRAY);
         } catch (\Exception $e) {
             $args['content'] = [];
         }

--- a/Builder/Managers/Tags.php
+++ b/Builder/Managers/Tags.php
@@ -162,7 +162,7 @@ class Tags
         return [
             'id' => $tagIdMatch[1],
             'name' => $tagNameMatch[1],
-            'settings' => \Laminas\Json\Json::decode(urldecode($tagSettingsMatch[1])),
+            'settings' => \Laminas\Json\Json::decode(urldecode($tagSettingsMatch[1]), \Laminas\Json\Json::TYPE_ARRAY),
         ];
     }
 
@@ -373,7 +373,7 @@ class Tags
             // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
             $tagName = base64_decode($tagKeyParts[0]);
 
-            $tagSettings = \Laminas\Json\Json::decode(urldecode(base64_decode($tagKeyParts[1])));
+            $tagSettings = \Laminas\Json\Json::decode(urldecode(base64_decode($tagKeyParts[1])), \Laminas\Json\Json::TYPE_ARRAY);
 
             $tag = $this->createTag(null, $tagName, $tagSettings);
 

--- a/Builder/Managers/Tags.php
+++ b/Builder/Managers/Tags.php
@@ -21,7 +21,6 @@ use Goomento\PageBuilder\Builder\Base\AbstractTag;
 use Goomento\PageBuilder\Helper\HooksHelper;
 use Goomento\PageBuilder\Helper\ObjectManagerHelper;
 use Goomento\PageBuilder\Traits\TraitComponentsLoader;
-use Zend_Json;
 
 class Tags
 {
@@ -163,7 +162,7 @@ class Tags
         return [
             'id' => $tagIdMatch[1],
             'name' => $tagNameMatch[1],
-            'settings' => Zend_Json::decode(urldecode($tagSettingsMatch[1])),
+            'settings' => \Laminas\Json\Json::decode(urldecode($tagSettingsMatch[1])),
         ];
     }
 
@@ -179,7 +178,7 @@ class Tags
      */
     public function tagToText(AbstractBaseTag $tag)
     {
-        return sprintf('[%1$s id="%2$s" name="%3$s" settings="%4$s"]', self::TAG_LABEL, $tag->getId(), $tag->getName(), urlencode(Zend_Json::encode($tag->getSettings())));
+        return sprintf('[%1$s id="%2$s" name="%3$s" settings="%4$s"]', self::TAG_LABEL, $tag->getId(), $tag->getName(), urlencode(\Laminas\Json\Json::encode($tag->getSettings())));
     }
 
     /**
@@ -374,7 +373,7 @@ class Tags
             // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
             $tagName = base64_decode($tagKeyParts[0]);
 
-            $tagSettings = \Zend_Json::decode(urldecode(base64_decode($tagKeyParts[1])));
+            $tagSettings = \Laminas\Json\Json::decode(urldecode(base64_decode($tagKeyParts[1])));
 
             $tag = $this->createTag(null, $tagName, $tagSettings);
 

--- a/Builder/Modules/Ajax.php
+++ b/Builder/Modules/Ajax.php
@@ -122,7 +122,7 @@ class Ajax extends AbstractModule
         HooksHelper::doAction('pagebuilder/ajax/register_actions', $this);
 
         try {
-            $this->ajaxRequestingActions = \Zend_Json::decode($requestParams['actions'] ?? '');
+            $this->ajaxRequestingActions = \Laminas\Json\Json::decode($requestParams['actions'] ?? '');
 
             $this->ajaxRequestingActions = EscaperHelper::filter($this->ajaxRequestingActions);
         } catch (\Exception $e) {

--- a/Builder/Modules/Ajax.php
+++ b/Builder/Modules/Ajax.php
@@ -122,7 +122,7 @@ class Ajax extends AbstractModule
         HooksHelper::doAction('pagebuilder/ajax/register_actions', $this);
 
         try {
-            $this->ajaxRequestingActions = \Laminas\Json\Json::decode($requestParams['actions'] ?? '');
+            $this->ajaxRequestingActions = \Laminas\Json\Json::decode($requestParams['actions'] ?? '', \Laminas\Json\Json::TYPE_ARRAY);
 
             $this->ajaxRequestingActions = EscaperHelper::filter($this->ajaxRequestingActions);
         } catch (\Exception $e) {

--- a/Builder/Sources/Local.php
+++ b/Builder/Sources/Local.php
@@ -402,7 +402,7 @@ class Local extends AbstractSource
     private function importSingleTemplate($fileName)
     {
         // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
-        $data = \Laminas\Json\Json::decode(file_get_contents($fileName));
+        $data = \Laminas\Json\Json::decode(file_get_contents($fileName), \Laminas\Json\Json::TYPE_ARRAY);
 
         if (empty($data)) {
             throw new BuilderException('Invalid file');

--- a/Builder/Sources/Local.php
+++ b/Builder/Sources/Local.php
@@ -21,7 +21,6 @@ use Goomento\PageBuilder\Helper\HooksHelper;
 use Goomento\PageBuilder\Helper\BuildableContentHelper;
 use Goomento\PageBuilder\Helper\ObjectManagerHelper;
 use Goomento\PageBuilder\Helper\UrlBuilderHelper;
-use Zend_Json;
 
 class Local extends AbstractSource
 {
@@ -403,7 +402,7 @@ class Local extends AbstractSource
     private function importSingleTemplate($fileName)
     {
         // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
-        $data = Zend_Json::decode(file_get_contents($fileName));
+        $data = \Laminas\Json\Json::decode(file_get_contents($fileName));
 
         if (empty($data)) {
             throw new BuilderException('Invalid file');
@@ -497,7 +496,7 @@ class Local extends AbstractSource
 
         return [
             'name' => $this->getJsonName($exportData),
-            'content' => Zend_Json::encode($exportData),
+            'content' => \Laminas\Json\Json::encode($exportData),
         ];
     }
 

--- a/Controller/Actions/Actions.php
+++ b/Controller/Actions/Actions.php
@@ -92,7 +92,7 @@ class Actions extends AbstractAction implements HttpPostActionInterface
 
         try {
             $elementData = $postData['actions'];
-            $elementData = (array) \Laminas\Json\Json::decode($elementData);
+            $elementData = (array) \Laminas\Json\Json::decode($elementData, \Laminas\Json\Json::TYPE_ARRAY);
         } catch (Exception $e) {
             $elementData = [];
         }

--- a/Controller/Actions/Actions.php
+++ b/Controller/Actions/Actions.php
@@ -20,7 +20,6 @@ use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
-use Zend_Json;
 
 class Actions extends AbstractAction implements HttpPostActionInterface
 {
@@ -93,7 +92,7 @@ class Actions extends AbstractAction implements HttpPostActionInterface
 
         try {
             $elementData = $postData['actions'];
-            $elementData = (array) Zend_Json::decode($elementData);
+            $elementData = (array) \Laminas\Json\Json::decode($elementData);
         } catch (Exception $e) {
             $elementData = [];
         }

--- a/Controller/Adminhtml/Content/Save.php
+++ b/Controller/Adminhtml/Content/Save.php
@@ -81,7 +81,7 @@ class Save extends AbstractContent implements HttpPostActionInterface
                     // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
                     $contentData = base64_decode($data['content_data']);
                     if ($contentData && DataHelper::isJson($contentData)) {
-                        $contentData = \Laminas\Json\Json::decode($contentData);
+                        $contentData = \Laminas\Json\Json::decode($contentData, \Laminas\Json\Json::TYPE_ARRAY);
                         if ($contentData !== $content->getElements()) {
                             $content->setElements($contentData);
                         }

--- a/Controller/Adminhtml/Content/Save.php
+++ b/Controller/Adminhtml/Content/Save.php
@@ -81,7 +81,7 @@ class Save extends AbstractContent implements HttpPostActionInterface
                     // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
                     $contentData = base64_decode($data['content_data']);
                     if ($contentData && DataHelper::isJson($contentData)) {
-                        $contentData = \Zend_Json::decode($contentData);
+                        $contentData = \Laminas\Json\Json::decode($contentData);
                         if ($contentData !== $content->getElements()) {
                             $content->setElements($contentData);
                         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -130,7 +130,7 @@ class Data extends AbstractHelper
             'builder_assistance/custom_pages'
         );
         try {
-            $pages = \Zend_Json::decode($pages);
+            $pages = \Laminas\Json\Json::decode($pages);
         } catch (\Exception $e) {
             $pages = [];
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -130,7 +130,7 @@ class Data extends AbstractHelper
             'builder_assistance/custom_pages'
         );
         try {
-            $pages = \Laminas\Json\Json::decode($pages);
+            $pages = \Laminas\Json\Json::decode($pages, \Laminas\Json\Json::TYPE_ARRAY);
         } catch (\Exception $e) {
             $pages = [];
         }

--- a/Helper/DataHelper.php
+++ b/Helper/DataHelper.php
@@ -256,7 +256,7 @@ class DataHelper
                 foreach ($attributeValues as &$value) {
                     if (!is_scalar($value)) {
                         if (is_array($value)) {
-                            $value = \Zend_Json::encode($value);
+                            $value = \Laminas\Json\Json::encode($value);
                         } elseif (is_object($value) && method_exists($value, '__toString')) {
                             $value = $value->__toString();
                         } else {

--- a/Helper/EncryptorHelper.php
+++ b/Helper/EncryptorHelper.php
@@ -95,7 +95,7 @@ class EncryptorHelper
         if (is_scalar($base)) {
             $key = $base;
         } elseif (is_array($base) || $base instanceof DataObject) {
-            $key = \Zend_Json::encode($base);
+            $key = \Laminas\Json\Json::encode($base);
         } elseif (is_object($base)) {
             $key = spl_object_hash($base);
         }

--- a/Helper/EscaperHelper.php
+++ b/Helper/EscaperHelper.php
@@ -47,9 +47,9 @@ class EscaperHelper
     public static function filter(array $data, bool $escaped = false)
     {
         if ($escaped) {
-            return (new \Zend_Filter_Input([], [], $data))->getEscaped();
+            return (new \Magento\Framework\Filter\FilterInput([], [], $data))->getEscaped();
         } else {
-            return (new \Zend_Filter_Input([], [], $data))->getUnescaped();
+            return (new \Magento\Framework\Filter\FilterInput([], [], $data))->getUnescaped();
         }
     }
 

--- a/Model/BetterCaching.php
+++ b/Model/BetterCaching.php
@@ -15,7 +15,6 @@ use Magento\Framework\DataObject;
 use Magento\Framework\App\Cache\TypeListInterface;
 use Goomento\PageBuilder\Model\Cache\Type\PageBuilderFrontend;
 use Goomento\PageBuilder\Model\Cache\Type\PageBuilderBackend;
-use Zend_Json;
 
 class BetterCaching
 {
@@ -169,7 +168,7 @@ class BetterCaching
         if (!empty($tags)) {
             if (!is_scalar($data)) {
                 try {
-                    $data = Zend_Json::encode($data);
+                    $data = \Laminas\Json\Json::encode($data);
                 } catch (\Exception $e) {
 
                 }
@@ -187,7 +186,7 @@ class BetterCaching
         $result = $this->cache->load($identifier);
         if ($result && (strpos($result, '{') !== 0 || strpos($result, '[') !== 0)) {
             try {
-                $result = Zend_Json::decode($result);
+                $result = \Laminas\Json\Json::decode($result);
             } catch (Exception $e) {
 
             }

--- a/Model/BetterCaching.php
+++ b/Model/BetterCaching.php
@@ -186,7 +186,7 @@ class BetterCaching
         $result = $this->cache->load($identifier);
         if ($result && (strpos($result, '{') !== 0 || strpos($result, '[') !== 0)) {
             try {
-                $result = \Laminas\Json\Json::decode($result);
+                $result = \Laminas\Json\Json::decode($result, \Laminas\Json\Json::TYPE_ARRAY);
             } catch (Exception $e) {
 
             }

--- a/Model/ContentDataProcessor.php
+++ b/Model/ContentDataProcessor.php
@@ -14,7 +14,6 @@ use Goomento\PageBuilder\Helper\EncryptorHelper;
 use Goomento\PageBuilder\Helper\HooksHelper;
 use Goomento\PageBuilder\PageBuilder;
 use Magento\Framework\Exception\LocalizedException;
-use Zend_Json;
 
 class ContentDataProcessor
 {
@@ -86,7 +85,7 @@ class ContentDataProcessor
      */
     public function getElementHtml(BuildableContentInterface $content, array $data) : string
     {
-        $key = EncryptorHelper::uniqueStringId(Zend_Json::encode($data));
+        $key = EncryptorHelper::uniqueStringId(\Laminas\Json\Json::encode($data));
 
         if (!isset($this->elements[$key])) {
 
@@ -117,7 +116,7 @@ class ContentDataProcessor
             );
         }
 
-        $key = EncryptorHelper::uniqueStringId(Zend_Json::encode($data));
+        $key = EncryptorHelper::uniqueStringId(\Laminas\Json\Json::encode($data));
 
         if (!isset($this->settings[$key])) {
 

--- a/Model/ItemProvider/ContentDataProvider.php
+++ b/Model/ItemProvider/ContentDataProvider.php
@@ -84,7 +84,7 @@ class ContentDataProvider extends ModifierPoolDataProvider
                 $this->loadedData[$content->getId()] = $content->getData();
                 $this->loadedData[$content->getId()]['content_data'] =
                     $content->getElements() ? base64_encode(
-                        \Zend_Json::encode($content->getElements())
+                        \Laminas\Json\Json::encode($content->getElements())
                     ) : '';
 
                 // Remove this for save the POST expense

--- a/Model/ResourceModel/Config.php
+++ b/Model/ResourceModel/Config.php
@@ -89,7 +89,7 @@ class Config extends AbstractDb
             foreach ($result as &$row) {
                 if (is_string($row['value'])) {
                     try {
-                        $row['value'] = \Laminas\Json\Json::decode($row['value']);
+                        $row['value'] = \Laminas\Json\Json::decode($row['value'], \Laminas\Json\Json::TYPE_ARRAY);
                     } catch (\Exception $e) {
 
                     }

--- a/Model/ResourceModel/Config.php
+++ b/Model/ResourceModel/Config.php
@@ -36,7 +36,7 @@ class Config extends AbstractDb
     {
         if (is_array($value)) {
             try {
-                $value = \Zend_Json::encode($value);
+                $value = \Laminas\Json\Json::encode($value);
             } catch (\Exception $e) {
 
             }
@@ -89,7 +89,7 @@ class Config extends AbstractDb
             foreach ($result as &$row) {
                 if (is_string($row['value'])) {
                     try {
-                        $row['value'] = \Zend_Json::decode($row['value']);
+                        $row['value'] = \Laminas\Json\Json::decode($row['value']);
                     } catch (\Exception $e) {
 
                     }

--- a/Plugin/Framework/Data/Form/Element/Editor.php
+++ b/Plugin/Framework/Data/Form/Element/Editor.php
@@ -13,7 +13,6 @@ use Goomento\PageBuilder\Helper\EscaperHelper;
 use Goomento\PageBuilder\Plugin\Ui\Component\Form\Element\Wysiwyg\BuilderAssistance;
 use Magento\Framework\Data\Form\Element\Editor as FormEditor;
 use Magento\Framework\UrlInterface;
-use Zend_Json;
 
 class Editor
 {
@@ -75,7 +74,7 @@ class Editor
                 ]
             ]
         ];
-        $js = '<script type="text/x-magento-init">' . Zend_Json::encode($jsParams) . '</script>';
+        $js = '<script type="text/x-magento-init">' . \Laminas\Json\Json::encode($jsParams) . '</script>';
         return '<div data-bind="scope: \'' . $componentName . '\'"><!-- ko template: getTemplate() --><!-- /ko --></div>' . $js;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "goomento/module-page-builder",
     "description": "Goomento - The Free Magento Page Builder Extension, allows you to create unique Magento websites, landing pages using advanced animations, custom CSS, responsive designs, and more, without a line of code.",
     "type": "magento2-module",
-    "version": "0.4.2",
+    "version": "0.4.2-p1",
     "license": [
         "OSL-3.0"
     ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "goomento/module-page-builder",
     "description": "Goomento - The Free Magento Page Builder Extension, allows you to create unique Magento websites, landing pages using advanced animations, custom CSS, responsive designs, and more, without a line of code.",
     "type": "magento2-module",
-    "version": "0.4.2-p1",
+    "version": "0.4.3",
     "license": [
         "OSL-3.0"
     ],

--- a/view/frontend/templates/extensions/snowdog_menu/menu.phtml
+++ b/view/frontend/templates/extensions/snowdog_menu/menu.phtml
@@ -30,7 +30,7 @@ if ($block->getMenu()): ?>
     <?php $menuClass = $block->getMenu()->getCssClass() ?>
     <nav class="<?= $block->escapeHtmlAttr($menuClass) ?>" data-action="navigation">
         <ul class="<?= $block->escapeHtmlAttr($menuClass) ?>__list gmt-menu-<?= $block->escapeHtmlAttr($type) ?>"
-            data-mage-init='<?= \Zend_Json::encode($menuJsWidget) ?>'>
+            data-mage-init='<?= \Laminas\Json\Json::encode($menuJsWidget) ?>'>
             <?php foreach ($block->getNodes() as $node): ?>
                 <?php
                 $childrenLevel = $node->getLevel() + 1;

--- a/view/frontend/templates/widgets/call_to_action.phtml
+++ b/view/frontend/templates/widgets/call_to_action.phtml
@@ -30,6 +30,6 @@ $dataMageInit = [
 ?>
 <script>
     require(['call-to-action'], function (callToAction) {
-        new callToAction(<?= \Zend_Json::encode($dataMageInit) ?>);
+        new callToAction(<?= \Laminas\Json\Json::encode($dataMageInit) ?>);
     });
 </script>

--- a/view/frontend/templates/widgets/video.phtml
+++ b/view/frontend/templates/widgets/video.phtml
@@ -86,7 +86,7 @@ $widget->addRenderAttribute('video-wrapper', 'class', 'gmt-open-' . ($settings['
 
             $widget->addRenderAttribute('image-overlay', [
                 'data-gmt-open-lightbox' => 'yes',
-                'data-gmt-lightbox' => Zend_Json::encode($lightboxOptions),
+                'data-gmt-lightbox' => \Laminas\Json\Json::encode($lightboxOptions),
             ]);
 
         } else {


### PR DESCRIPTION
Magento 2.4.6 removed the Zend_Json library from its dependencies. [See here](https://developer-stage.adobe.com/commerce/php/development/backward-incompatible-changes/highlights/#246)

> 2.4.6
> The following major backward-incompatible changes were introduced in the 2.4.6 Adobe Commerce and Magento Open Source releases:
> - ...
> - Zend_Json replaced with laminas-json
> - ...

This PR replaces all `Zend_Json` referenes with it's Laminas equivalent `Laminas\Json\Json`.

Related PR: Goomento/PageBuilderApi/pull/1 
Related Issue: Goomento/PageBuilder/issues/26